### PR TITLE
fixed cluster width issue, now fits in modal

### DIFF
--- a/app/templates/search-template.html
+++ b/app/templates/search-template.html
@@ -155,7 +155,7 @@ body {
     </div>
     <div class="box-content" id="timeline">
 	<div class="row">
-		<div id="foamtree" class="span6" style="width: 600px; height: 400px">
+		<div id="foamtree" class="span6">
 			Loading Carrot Search FoamTree visualization...
 		</div>
 		<div id="circles" class="span6" style="width: 400px; height: 600px">


### PR DESCRIPTION
This ensures that the clusters fit within the modal and don't spill over. It also enables it to resize with the bootstrap div.
